### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2006-2026 SIL Global
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LIFTDotNet/lib/Commons.Xml.Relaxng.LICENSE.txt
+++ b/LIFTDotNet/lib/Commons.Xml.Relaxng.LICENSE.txt
@@ -1,0 +1,15 @@
+Commons.Xml.Relaxng (bundled here as Commons.Xml.Relaxng.dll)
+Upstream: https://github.com/atsushieno/dotnet-dsdl (also shipped as part of the Mono project)
+License: MIT — reproduced verbatim below from the upstream LICENSE.txt
+
+----------------------------------------------------------------------
+
+Copyright (C) 2003,2017 Atsushi Eno
+Copyright (C) 2004-2011 Novell Inc.
+Copyright (C) 2012 Xamarin Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ The most recent published version is **0.13**:
 - [LIFT 0.13 Specification (PDF)](https://github.com/sillsdev/lift-standard/blob/master/lift_13.pdf)  
 - [LIFT 0.13 RelaxNG Schema (.rng)](https://github.com/sillsdev/lift-standard/blob/master/lift-0.13.rng)  
 
-
 ---
 
 ## Resources
@@ -50,3 +49,10 @@ The most recent published version is **0.13**:
 - [Archived Project Page](https://code.google.com/archive/p/lift-standard/)  
 - [Downloads](https://code.google.com/archive/p/lift-standard/downloads) — schema files and specification documents  
 
+---
+
+## License
+
+[MIT](LICENSE)
+
+The binaries under [`LIFTDotNet/lib/`](LIFTDotNet/lib/) are bundled third-party libraries under their own (permissive) upstream licenses.


### PR DESCRIPTION
Resolves #6

Also adds the license file for the one bundled 3rd-party lib (copied from https://github.com/atsushieno/dotnet-dsdl/blob/master/LICENSE.txt).

Devin review: https://app.devin.ai/review/sillsdev/lift-standard/pull/7